### PR TITLE
ENG-2350 amended silent sso checker for keycloak to avoid redirection during sso checks

### DIFF
--- a/src/main/resources/liquibase/defaultResources/port/clob/production/guifragment_14.ftl
+++ b/src/main/resources/liquibase/defaultResources/port/clob/production/guifragment_14.ftl
@@ -1,8 +1,9 @@
 <#assign wp=JspTaglibs["/aps-core"]>
+<@wp.info key="systemParam" paramName="applicationBaseURL" var="appUrl" />
 <script nonce="<@wp.cspNonce />" >
   (function () {
     const consolePrefix = '[ENTANDO-KEYCLOAK]';
-    const keycloakConfigEndpoint = '<@wp.info key="systemParam" paramName="applicationBaseURL" />keycloak.json';
+    const keycloakConfigEndpoint = '${appUrl}keycloak.json';
     let keycloakConfig;
     function dispatchKeycloakEvent(eventType) {
       console.info(consolePrefix, 'Dispatching', eventType, 'custom event');
@@ -43,7 +44,7 @@
         keycloak,
       };
       window.entando.keycloak
-        .init({ onLoad: 'check-sso', promiseType: 'native', enableLogging: true })
+        .init({ onLoad: 'check-sso', silentCheckSsoRedirectUri: '${appUrl}resources/static/silent-check-sso.html', promiseType: 'native', enableLogging: true })
         .then(onKeycloakInitialized)
         .catch(function (e) {
           console.error(e);

--- a/src/main/webapp/resources/static/silent-check-sso.html
+++ b/src/main/webapp/resources/static/silent-check-sso.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>entando_silent_sso_check</title>
+  </head>
+  <body>
+    <script>
+      parent.postMessage(location.href, location.origin);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This will basically enable SSO checks "silently". No redirect mechanism to avoid request body removal during form request after SSO verification. credits to @nshaw for the method suggestion.

As @w-caffiero-entando remarked, nonce insertion is not necessary on the created html file in this PR.

Here are some silent SSO check method for Keycloak references:
https://github.com/keycloak/keycloak-documentation/blob/master/securing_apps/topics/oidc/javascript-adapter.adoc
https://github.com/mauriciovigolo/keycloak-angular#setup
OLD PR (closed): https://github.com/entando/entando-de-app/pull/240

To test this, you must use "News Archive" widget (the form of this widget) for your keycloak-enabled page. using typical sso check will drop the form request since every page load redirects to keycloak for SSO checking. Silent SSO checking will check SSO using iframe afaik.